### PR TITLE
replace deprecated options

### DIFF
--- a/s6/nmbd.run
+++ b/s6/nmbd.run
@@ -1,3 +1,3 @@
 #!/usr/bin/execlineb -P
 
-nmbd --foreground --no-process-group --log-stdout
+nmbd --foreground --no-process-group --debug-stdout

--- a/s6/smbd.run
+++ b/s6/smbd.run
@@ -1,3 +1,3 @@
 #!/usr/bin/execlineb -P
 
-smbd --foreground --no-process-group --log-stdout
+smbd --foreground --no-process-group --debug-stdout


### PR DESCRIPTION
see https://wiki.samba.org/index.php/Samba_4.15_Features_added/changed#Duplicates_in_command_line_utils for details

fixes this behavior 
```
Invalid option --log-stdout: unknown option

Usage: smbd [-?bDiFV] [-?|--help] [--usage] [-b|--build-options]
        [-p|--port=STRING] [-P|--profiling-level=PROFILE_LEVEL]
        [-d|--debuglevel=DEBUGLEVEL] [--debug-stdout]
        [-s|--configfile=CONFIGFILE] [--option=name=value]
        [-l|--log-basename=LOGFILEBASE] [--leak-report] [--leak-report-full]
        [-D|--daemon] [-i|--interactive] [-F|--foreground]
        [--no-process-group] [-V|--version]

Invalid options

Usage: nmbd [-?DiFV] [-?|--help] [--usage] [-H|--hosts=STRING]
        [-p|--port=INT] [-d|--debuglevel=DEBUGLEVEL] [--debug-stdout]
        [-s|--configfile=CONFIGFILE] [--option=name=value]
        [-l|--log-basename=LOGFILEBASE] [--leak-report] [--leak-report-full]
        [-D|--daemon] [-i|--interactive] [-F|--foreground]
        [--no-process-group] [-V|--version]

Invalid option --log-stdout: unknown option
```