### PR TITLE
Fix incorrect `tee` usage

### DIFF
--- a/s6/config.init
+++ b/s6/config.init
@@ -2,4 +2,4 @@
 
 addgroup -g $GID samba > /dev/null 2&>1
 adduser -S -G samba -u $UID -H -D $USERNAME
-echo "$PASSWORD" | tee - | smbpasswd -s -c /etc/samba/smb.conf -a $USERNAME
+echo "$PASSWORD" | tee /dev/stdout | smbpasswd -s -c /etc/samba/smb.conf -a $USERNAME


### PR DESCRIPTION
`tee` doesn't accept `-` as an alias for `/dev/stdout` like cat does